### PR TITLE
Make MapperNotFound a proper dbus exception

### DIFF
--- a/OpenBMCMapper.py
+++ b/OpenBMCMapper.py
@@ -23,10 +23,7 @@ MAPPER_NAME = 'org.openbmc.objectmapper'
 MAPPER_IFACE = MAPPER_NAME + '.ObjectMapper'
 MAPPER_PATH = '/org/openbmc/objectmapper/objectmapper'
 ENUMERATE_IFACE = 'org.openbmc.Object.Enumerate'
-
-class MapperNotFoundException(Exception):
-	def __init__(self, msg):
-		super(MapperNotFoundException, self).__init__(msg)
+MAPPER_NOT_FOUND = 'org.openbmc.objectmapper.Error.NotFound'
 
 class Path:
 	def __init__(self, path):

--- a/phosphor-mapper
+++ b/phosphor-mapper
@@ -16,13 +16,19 @@
 # implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-import sys
 import dbus
 import dbus.service
+import dbus.exceptions
 import dbus.mainloop.glib
 import gobject
-from OpenBMCMapper import Path, IntrospectionParser, PathTree
+from OpenBMCMapper import IntrospectionParser, PathTree
 import OpenBMCMapper
+
+class MapperNotFoundException(dbus.exceptions.DBusException):
+	_dbus_error_name = OpenBMCMapper.MAPPER_NOT_FOUND
+	def __init__(self, path):
+		super(MapperNotFoundException, self).__init__(
+				"path or object not found: %s" %(path))
 
 class ObjectMapper(dbus.service.Object):
 	def __init__(self, bus, path,


### PR DESCRIPTION
Set the name to org.openbmc.objectmapper.Error.NotFound