### PR TITLE
Add an accessor function for cache entries

### DIFF
--- a/phosphor-mapper
+++ b/phosphor-mapper
@@ -139,12 +139,18 @@ class ObjectMapper(dbus.service.Object):
     def discovery_pending(self):
         return not bool(self.service)
 
+    def cache_get(self, path):
+        cache_entry = self.cache.get(path, {})
+        if cache_entry is None:
+            # hide path elements without any interfaces
+            cache_entry = {}
+        return cache_entry
+
     def add_new_objmgr(self, path, owner):
         # We don't get a signal for the ObjectManager
         # interface itself, so if we see a signal from
         # make sure its in our cache, and add it if not.
-        cache_entry = self.cache.get(path, {})
-        cache_entry = cache_entry if cache_entry is not None else {}
+        cache_entry = self.cache_get(path)
         old = self.interfaces_get(cache_entry, owner)
         new = list(set(old).union([dbus.BUS_DAEMON_IFACE + '.ObjectManager']))
         self.update_interfaces(path, owner, old, new)
@@ -152,9 +158,10 @@ class ObjectMapper(dbus.service.Object):
     def interfaces_added_handler(self, path, iprops, **kw):
         path = str(path)
         owner = str(kw['sender'])
-        self.add_new_objmgr(str(kw['sender_path']), owner)
         interfaces = self.get_signal_interfaces(owner, iprops.iterkeys())
-        cache_entry = self.cache.get(path, {})
+        if interfaces:
+            self.add_new_objmgr(str(kw['sender_path']), owner)
+        cache_entry = self.cache_get(path)
         old = self.interfaces_get(cache_entry, owner)
         new = list(set(interfaces).union(old))
         self.update_interfaces(path, owner, old, new)
@@ -162,9 +169,10 @@ class ObjectMapper(dbus.service.Object):
     def interfaces_removed_handler(self, path, interfaces, **kw):
         path = str(path)
         owner = str(kw['sender'])
-        self.add_new_objmgr(str(kw['sender_path']), owner)
         interfaces = self.get_signal_interfaces(owner, interfaces)
-        cache_entry = self.cache.get(path, {})
+        if interfaces:
+            self.add_new_objmgr(str(kw['sender_path']), owner)
+        cache_entry = self.cache_get(path)
         old = self.interfaces_get(cache_entry, owner)
         new = list(set(old).difference(interfaces))
         self.update_interfaces(path, owner, old, new)
@@ -307,7 +315,7 @@ class ObjectMapper(dbus.service.Object):
 
     @dbus.service.method(obmc.mapper.MAPPER_IFACE, 's', 'a{sas}')
     def GetObject(self, path):
-        o = self.cache.get(path)
+        o = self.cache_get(path)
         if not o:
             raise MapperNotFoundException(path)
         return o
@@ -431,7 +439,7 @@ class ObjectMapper(dbus.service.Object):
                 'reverse', endpoint, owner, forward_path)
 
             # create the association if the endpoint exists
-            if self.cache.get(endpoint, None) is None:
+            if not self.cache_get(endpoint):
                 continue
 
             self.update_association(forward_path, [], [endpoint])
@@ -481,8 +489,8 @@ class ObjectMapper(dbus.service.Object):
             paths.append('/')
 
         for path in paths:
-            obj = self.cache.get(path, None)
-            if obj is None:
+            obj = self.cache_get(path)
+            if not obj:
                 continue
             objs[path] = obj
 


### PR DESCRIPTION
Determining the difference between a directory path element
and a path element that doesn't exist with pyphosphor is
awkward.  Create an accessor function to funnel this weirdness
in one spot.

Make sure objectmanagers adhere to match rules before adding them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/phosphor-objmgr/10)
<!-- Reviewable:end -->
